### PR TITLE
Combined other forks features and added a bit myself

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "FluidMenuBarExtra",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v12)],
     products: [
         .library(
             name: "FluidMenuBarExtra",

--- a/Sources/FluidMenuBarExtra/EventMonitor.swift
+++ b/Sources/FluidMenuBarExtra/EventMonitor.swift
@@ -20,9 +20,11 @@ class EventMonitor {
         stop()
     }
 
+    // swiftlint: disable unavailable_function
     func start() {
         fatalError("start must be implemented by a subclass of EventMonitor")
     }
+    // swiftlint: enable unavailable_function
 
     func stop() {
         if monitor != nil {

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
@@ -50,4 +50,8 @@ public final class FluidMenuBarExtra {
         let window = FluidMenuBarExtraWindow(title: title, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, systemImage: systemImage, window: window)
     }
+
+    public func toggleMenuBarExtra() {
+        statusItem.toggleWindow()
+    }
 }

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
@@ -34,7 +34,7 @@ import SwiftUI
 /// your application delegate to the child views using the `environmentObject`
 /// modifier.
 public final class FluidMenuBarExtra {
-    private let statusItem: FluidMenuBarExtraStatusItem
+    public let statusItem: FluidMenuBarExtraStatusItem
 
     public init(
         title: String,

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
@@ -36,12 +36,19 @@ import SwiftUI
 public final class FluidMenuBarExtra {
     public let statusItem: FluidMenuBarExtraStatusItem
 
+    public var image: NSImage? {
+        get { statusItem.statusItem.button?.image }
+        set { statusItem.statusItem.button?.image = newValue }
+    }
+    
     public init(
         title: String,
         menuBarExtraDelegate: FluidMenuBarExtraDelegate? = nil,
+        cornerRadius: CGFloat = 7,
+        maskedCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner],
         @ViewBuilder content: @escaping () -> some View
     ) {
-        let window = FluidMenuBarExtraWindow(title: title, content: content)
+        let window = FluidMenuBarExtraWindow(title: title, cornerRadius: cornerRadius, maskedCorners: maskedCorners, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, window: window)
         statusItem.menuBarExtraDelegate = menuBarExtraDelegate
     }
@@ -50,9 +57,11 @@ public final class FluidMenuBarExtra {
         title: String,
         image: String,
         menuBarExtraDelegate: FluidMenuBarExtraDelegate? = nil,
+        cornerRadius: CGFloat = 7,
+        maskedCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner],
         @ViewBuilder content: @escaping () -> some View
     ) {
-        let window = FluidMenuBarExtraWindow(title: title, content: content)
+        let window = FluidMenuBarExtraWindow(title: title, cornerRadius: cornerRadius, maskedCorners: maskedCorners, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, image: image, window: window)
         statusItem.menuBarExtraDelegate = menuBarExtraDelegate
     }
@@ -61,11 +70,34 @@ public final class FluidMenuBarExtra {
         title: String,
         systemImage: String,
         menuBarExtraDelegate: FluidMenuBarExtraDelegate? = nil,
+        cornerRadius: CGFloat = 7,
+        maskedCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner],
         @ViewBuilder content: @escaping () -> some View
     ) {
-        let window = FluidMenuBarExtraWindow(title: title, content: content)
+        let window = FluidMenuBarExtraWindow(title: title, cornerRadius: cornerRadius, maskedCorners: maskedCorners, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, systemImage: systemImage, window: window)
         statusItem.menuBarExtraDelegate = menuBarExtraDelegate
+    }
+    
+    public init(
+        title: String,
+        nsImage: NSImage,
+        menuBarExtraDelegate: FluidMenuBarExtraDelegate? = nil,
+        cornerRadius: CGFloat = 7,
+        maskedCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner],
+        @ViewBuilder content: @escaping () -> some View
+    ) {
+        let window = FluidMenuBarExtraWindow(title: title, cornerRadius: cornerRadius, maskedCorners: maskedCorners, content: content)
+        statusItem = FluidMenuBarExtraStatusItem(title: title, nsImage: nsImage, window: window)
+        statusItem.menuBarExtraDelegate = menuBarExtraDelegate
+    }
+    
+    public func showWindow() {
+        statusItem.showWindow()
+    }
+    
+    public func closeWindow() {
+        statusItem.dismissWindow()
     }
 
     public func toggleMenuBarExtra() {

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
@@ -36,19 +36,36 @@ import SwiftUI
 public final class FluidMenuBarExtra {
     private let statusItem: FluidMenuBarExtraStatusItem
 
-    public init(title: String, @ViewBuilder content: @escaping () -> some View) {
+    public init(
+        title: String,
+        menuBarExtraDelegate: FluidMenuBarExtraDelegate? = nil,
+        @ViewBuilder content: @escaping () -> some View
+    ) {
         let window = FluidMenuBarExtraWindow(title: title, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, window: window)
+        statusItem.menuBarExtraDelegate = menuBarExtraDelegate
     }
 
-    public init(title: String, image: String, @ViewBuilder content: @escaping () -> some View) {
+    public init(
+        title: String,
+        image: String,
+        menuBarExtraDelegate: FluidMenuBarExtraDelegate? = nil,
+        @ViewBuilder content: @escaping () -> some View
+    ) {
         let window = FluidMenuBarExtraWindow(title: title, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, image: image, window: window)
+        statusItem.menuBarExtraDelegate = menuBarExtraDelegate
     }
 
-    public init(title: String, systemImage: String, @ViewBuilder content: @escaping () -> some View) {
+    public init(
+        title: String,
+        systemImage: String,
+        menuBarExtraDelegate: FluidMenuBarExtraDelegate? = nil,
+        @ViewBuilder content: @escaping () -> some View
+    ) {
         let window = FluidMenuBarExtraWindow(title: title, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, systemImage: systemImage, window: window)
+        statusItem.menuBarExtraDelegate = menuBarExtraDelegate
     }
 
     public func toggleMenuBarExtra() {

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraDelegate.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  FluidMenuBarExtraDelegate.swift
+//  
+//
+//  Created by Adam on 20/04/2023.
+//
+
+import Foundation
+
+public protocol FluidMenuBarExtraDelegate: AnyObject {
+    func menuBarExtraBecomeActive()
+    func menuBarExtraWasDeactivated()
+}

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraDelegate.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraDelegate.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public protocol FluidMenuBarExtraDelegate: AnyObject {
+    func menuBarExtraShouldBecomeActive() -> Bool
     func menuBarExtraBecomeActive()
     func menuBarExtraWasDeactivated()
 }

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
@@ -11,9 +11,9 @@ import SwiftUI
 
 /// An individual element displayed in the system menu bar that displays a window
 /// when triggered.
-final class FluidMenuBarExtraStatusItem: NSObject {
+public final class FluidMenuBarExtraStatusItem: NSObject {
     private let window: NSWindow
-    private let statusItem: NSStatusItem
+    public let statusItem: NSStatusItem
     weak var menuBarExtraDelegate: FluidMenuBarExtraDelegate?
 
     private var localEventMonitor: EventMonitor?

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
@@ -96,6 +96,7 @@ final class FluidMenuBarExtraStatusItem: NSObject {
             self?.window.orderOut(nil)
             self?.window.alphaValue = 1
         }
+        menuBarExtraDelegate?.menuBarExtraWasDeactivated()
     }
 
     private func setButtonHighlighted(to highlight: Bool) {

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
@@ -48,7 +48,7 @@ final class FluidMenuBarExtraStatusItem: NSObject, NSWindowDelegate {
         NSStatusBar.system.removeStatusItem(statusItem)
     }
 
-    private func didPressStatusBarButton(_ sender: NSStatusBarButton) {
+    func toggleWindow() {
         if window.isVisible {
             dismissWindow()
             return
@@ -59,6 +59,10 @@ final class FluidMenuBarExtraStatusItem: NSObject, NSWindowDelegate {
         // Tells the system to persist the menu bar in full screen mode.
         DistributedNotificationCenter.default().post(name: .beginMenuTracking, object: nil)
         window.makeKeyAndOrderFront(nil)
+    }
+
+    private func didPressStatusBarButton(_ sender: NSStatusBarButton) {
+        toggleWindow()
     }
 
     func windowDidBecomeKey(_ notification: Notification) {

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
@@ -14,6 +14,7 @@ import SwiftUI
 final class FluidMenuBarExtraStatusItem: NSObject {
     private let window: NSWindow
     private let statusItem: NSStatusItem
+    weak var menuBarExtraDelegate: FluidMenuBarExtraDelegate?
 
     private var localEventMonitor: EventMonitor?
     private var globalEventMonitor: EventMonitor?
@@ -67,6 +68,7 @@ final class FluidMenuBarExtraStatusItem: NSObject {
                 name: NSWorkspace.activeSpaceDidChangeNotification,
                 object: nil
             )
+        menuBarExtraDelegate?.menuBarExtraBecomeActive()
     }
 
     private func didPressStatusBarButton(_ sender: NSStatusBarButton) {

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
@@ -54,6 +54,9 @@ public final class FluidMenuBarExtraStatusItem: NSObject {
             dismissWindow()
             return
         }
+        if let menuBarExtraDelegate, !menuBarExtraDelegate.menuBarExtraShouldBecomeActive() {
+            return
+        }
         setWindowPosition()
         setButtonHighlighted(to: true)
         // Tells the system to persist the menu bar in full screen mode.
@@ -75,7 +78,15 @@ public final class FluidMenuBarExtraStatusItem: NSObject {
         toggleWindow()
     }
 
-    private func dismissWindow() {
+    func showWindow() {
+        guard !window.isVisible,
+              let button = statusItem.button
+        else { return }
+
+        didPressStatusBarButton(button)
+    }
+
+    func dismissWindow() {
         setButtonHighlighted(to: false)
         // Tells the system to cancel persisting the menu bar in full screen mode.
         DistributedNotificationCenter.default().post(name: .endMenuTracking, object: nil)
@@ -111,6 +122,7 @@ public final class FluidMenuBarExtraStatusItem: NSObject {
         }
 
         var targetRect = statusItemWindow.frame
+        targetRect.origin.y -= 1;
 
         if let screen = statusItemWindow.screen {
             let windowWidth = window.frame.width
@@ -160,6 +172,12 @@ extension FluidMenuBarExtraStatusItem {
         self.init(window: window)
         statusItem.button?.setAccessibilityTitle(title)
         statusItem.button?.image = NSImage(systemSymbolName: systemImage, accessibilityDescription: title)
+    }
+    
+    convenience init(title: String, nsImage: NSImage, window: NSWindow) {
+        self.init(window: window)
+        statusItem.button?.setAccessibilityTitle(title)
+        statusItem.button?.image = nsImage
     }
 }
 

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
@@ -46,7 +46,9 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
     private lazy var hostingView: NSHostingView<some View> = {
         let view = NSHostingView(rootView: rootView)
         // Disable NSHostingView's default automatic sizing behavior.
-        view.sizingOptions = []
+        if #available(macOS 13, *) {
+            view.sizingOptions = []
+        }
         view.isVerticalContentSizeConstraintActive = false
         view.isHorizontalContentSizeConstraintActive = false
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -76,7 +78,11 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
         hasShadow = true
 
         animationBehavior = .none
-        collectionBehavior = [.auxiliary, .transient, .moveToActiveSpace, .fullScreenAuxiliary]
+        if #available(macOS 13, *) {
+            collectionBehavior = [.auxiliary, .transient, .moveToActiveSpace, .fullScreenAuxiliary]
+        } else {
+            collectionBehavior = [.transient, .moveToActiveSpace, .fullScreenAuxiliary]
+        }
         isReleasedWhenClosed = false
         hidesOnDeactivate = false
 

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
@@ -18,9 +18,19 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
 
     private lazy var visualEffectView: NSVisualEffectView = {
         let view = NSVisualEffectView()
+        view.wantsLayer = true
         view.blendingMode = .behindWindow
         view.state = .active
         view.material = .underWindowBackground
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer?.cornerRadius = 8
+        view.layer?.cornerCurve = .continuous
+        return view
+    }()
+
+    // without it NSWindow/NSPanel will draw gross border around window, that will ignore visualEffectView's corner radius
+    private lazy var backgroundView: NSView = {
+        let view = NSView()
         view.translatesAutoresizingMaskIntoConstraints = true
         return view
     }()
@@ -48,7 +58,7 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
 
         super.init(
             contentRect: CGRect(x: 0, y: 0, width: 100, height: 100),
-            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .fullSizeContentView],
+            styleMask: [.borderless],
             backing: .buffered,
             defer: false
         )
@@ -62,6 +72,8 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
         isOpaque = false
         titleVisibility = .hidden
         titlebarAppearsTransparent = true
+        backgroundColor = .clear
+        hasShadow = true
 
         animationBehavior = .none
         collectionBehavior = [.auxiliary, .stationary, .moveToActiveSpace, .fullScreenAuxiliary]
@@ -72,11 +84,16 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
         standardWindowButton(.miniaturizeButton)?.isHidden = true
         standardWindowButton(.zoomButton)?.isHidden = true
 
-        contentView = visualEffectView
+        contentView = backgroundView
+        backgroundView.addSubview(visualEffectView)
         visualEffectView.addSubview(hostingView)
         setContentSize(hostingView.intrinsicContentSize)
 
         NSLayoutConstraint.activate([
+            visualEffectView.topAnchor.constraint(equalTo: backgroundView.topAnchor),
+            visualEffectView.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor),
+            visualEffectView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor),
+            visualEffectView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor),
             hostingView.topAnchor.constraint(equalTo: visualEffectView.topAnchor),
             hostingView.trailingAnchor.constraint(equalTo: visualEffectView.trailingAnchor),
             hostingView.bottomAnchor.constraint(equalTo: visualEffectView.bottomAnchor),

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
@@ -16,17 +16,18 @@ import SwiftUI
 final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
     private let content: () -> Content
 
-    private lazy var visualEffectView: NSVisualEffectView = {
+    private func createVisualEffectView(cornerRadius: CGFloat, maskedCorners: CACornerMask) -> NSVisualEffectView {
         let view = NSVisualEffectView()
         view.wantsLayer = true
         view.blendingMode = .behindWindow
         view.state = .active
         view.material = .underWindowBackground
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.layer?.cornerRadius = 8
+        view.layer?.cornerRadius = cornerRadius
+        view.layer?.maskedCorners = maskedCorners
         view.layer?.cornerCurve = .continuous
         return view
-    }()
+    }
 
     // without it NSWindow/NSPanel will draw gross border around window, that will ignore visualEffectView's corner radius
     private lazy var backgroundView: NSView = {
@@ -55,11 +56,11 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
         return view
     }()
 
-    init(title: String, content: @escaping () -> Content) {
+    init(title: String, cornerRadius: CGFloat, maskedCorners: CACornerMask, content: @escaping () -> Content) {
         self.content = content
 
         super.init(
-            contentRect: CGRect(x: 0, y: 0, width: 100, height: 100),
+            contentRect: CGRect.zero,
             styleMask: [.borderless],
             backing: .buffered,
             defer: false
@@ -91,6 +92,7 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
         standardWindowButton(.zoomButton)?.isHidden = true
 
         contentView = backgroundView
+        let visualEffectView = createVisualEffectView(cornerRadius: cornerRadius, maskedCorners: maskedCorners)
         backgroundView.addSubview(visualEffectView)
         visualEffectView.addSubview(hostingView)
         setContentSize(hostingView.intrinsicContentSize)

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
@@ -20,7 +20,7 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
         let view = NSVisualEffectView()
         view.blendingMode = .behindWindow
         view.state = .active
-        view.material = .popover
+        view.material = .underWindowBackground
         view.translatesAutoresizingMaskIntoConstraints = true
         return view
     }()

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
@@ -76,7 +76,7 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
         hasShadow = true
 
         animationBehavior = .none
-        collectionBehavior = [.auxiliary, .stationary, .moveToActiveSpace, .fullScreenAuxiliary]
+        collectionBehavior = [.auxiliary, .transient, .moveToActiveSpace, .fullScreenAuxiliary]
         isReleasedWhenClosed = false
         hidesOnDeactivate = false
 

--- a/Sources/FluidMenuBarExtra/RootViewModifier.swift
+++ b/Sources/FluidMenuBarExtra/RootViewModifier.swift
@@ -35,8 +35,8 @@ struct RootViewModifier: ViewModifier {
                         .onAppear {
                             updateSize?(size: geometry.size)
                         }
-                        .onChange(of: geometry.size) { newValue in
-                            updateSize?(size: geometry.size)
+                        .onChange(of: geometry.size) { size in
+                            updateSize?(size: size)
                         }
                 }
             )


### PR DESCRIPTION
Hi,
I'm trying to make a screen recorder menu app and needed a few things. Instead of writing my own or just using one of the forks that never created a PR, I combined the best of theirs with a few changes I needed myself.

By using a custom icon renderer I can control stopping the recording with just the click on the icon. Example:
```swift
class AppDelegate: NSObject, NSApplicationDelegate, FluidMenuBarExtraDelegate {
    
    var menuBarExtra: FluidMenuBarExtra?
    var recording = false
    
    @MainActor func makeImage() -> NSImage {
        let renderer = ImageRenderer(content: RenderView(recording: recording))
        renderer.scale = 1
        return renderer.nsImage!
    }
    
    @MainActor func menuBarExtraShouldBecomeActive() -> Bool {
        if recording {
            recording = false
            menuBarExtra?.image = makeImage()
            return false
        }
        return true
    }
    
    func menuBarExtraBecomeActive() {
    }
    
    @MainActor func menuBarExtraWasDeactivated() {
        menuBarExtra?.image = makeImage()
    }
    
    func applicationDidFinishLaunching(_ notification: Notification) {
        self.menuBarExtra = FluidMenuBarExtra(title: "Test", nsImage: makeImage(), menuBarExtraDelegate: self) {
            Group {
                Button("Start Recording") {
                    self.recording = true
                    self.menuBarExtra?.closeWindow()
                }
            }
            .padding()
        }
    }
}
```

Hope this works for you. I kept the changes to a minimum
/Andreas