### PR TITLE
Add a controller environment object that allows SwiftUI views within the MenuBarExtra to control visibility state

### DIFF
--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtra.swift
@@ -34,20 +34,35 @@ import SwiftUI
 /// your application delegate to the child views using the `environmentObject`
 /// modifier.
 public final class FluidMenuBarExtra {
+    
+    // MARK: Public private(set)
+    
+    public private(set) var controller: FluidMenuBarExtraController = FluidMenuBarExtraController()
+    
+    // MARK: Private
+    
     private let statusItem: FluidMenuBarExtraStatusItem
+    
+    // MARK: Lifecycle
 
     public init(title: String, @ViewBuilder content: @escaping () -> some View) {
         let window = FluidMenuBarExtraWindow(title: title, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, window: window)
+        window.controller.statusItem = statusItem
+        controller = window.controller
     }
 
     public init(title: String, image: String, @ViewBuilder content: @escaping () -> some View) {
         let window = FluidMenuBarExtraWindow(title: title, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, image: image, window: window)
+        window.controller.statusItem = statusItem
+        controller = window.controller
     }
 
     public init(title: String, systemImage: String, @ViewBuilder content: @escaping () -> some View) {
         let window = FluidMenuBarExtraWindow(title: title, content: content)
         statusItem = FluidMenuBarExtraStatusItem(title: title, systemImage: systemImage, window: window)
+        window.controller.statusItem = statusItem
+        controller = window.controller
     }
 }

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraController.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraController.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright © 2023 Hidden Spectrum, LLC. All rights reserved.
+//
+
+import SwiftUI
+
+
+public class FluidMenuBarExtraController: ObservableObject {
+    
+    // MARK: Public
+    
+    public var isWindowVisible: Bool { statusItem?.isWindowVisible ?? false }
+    
+    // MARK: Internal
+    
+    weak var statusItem: FluidMenuBarExtraStatusItem?
+    
+    // MARK: Visibility
+    
+    public func showWindow() {
+        statusItem?.showWindow()
+    }
+    
+    public func dismissWindow() {
+        statusItem?.dismissWindow()
+    }
+}

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraController.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraController.swift
@@ -21,7 +21,20 @@ public class FluidMenuBarExtraController: ObservableObject {
         statusItem?.showWindow()
     }
     
-    public func dismissWindow() {
-        statusItem?.dismissWindow()
+    public func dismissWindow(animate: Bool = true, completionHandler: (() -> Void)? = nil) {
+        guard let statusItem else {
+            completionHandler?()
+            return
+        }
+        statusItem.dismissWindow(animate: animate, completionHandler: completionHandler)
+    }
+    
+    @MainActor
+    public func dismissWindow(animate: Bool = true) async {
+        await withCheckedContinuation { continuation in
+            dismissWindow(animate: animate) {
+                continuation.resume()
+            }
+        }
     }
 }

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
@@ -12,11 +12,22 @@ import SwiftUI
 /// An individual element displayed in the system menu bar that displays a window
 /// when triggered.
 final class FluidMenuBarExtraStatusItem: NSObject, NSWindowDelegate {
+    
+    // MARK: Internal
+    
+    var isWindowVisible: Bool {
+        window.isVisible
+    }
+    
+    // MARK: Private
+    
     private let window: NSWindow
     private let statusItem: NSStatusItem
 
     private var localEventMonitor: EventMonitor?
     private var globalEventMonitor: EventMonitor?
+    
+    // MARK: Lifecycle
 
     private init(window: NSWindow) {
         self.window = window
@@ -58,7 +69,10 @@ final class FluidMenuBarExtraStatusItem: NSObject, NSWindowDelegate {
             dismissWindow()
             return
         }
-
+        showWindow()
+    }
+    
+    func showWindow() {
         setWindowPosition()
 
         // Tells the system to persist the menu bar in full screen mode.
@@ -76,10 +90,10 @@ final class FluidMenuBarExtraStatusItem: NSObject, NSWindowDelegate {
         dismissWindow()
     }
 
-    private func dismissWindow() {
+    func dismissWindow() {
         // Tells the system to cancel persisting the menu bar in full screen mode.
         DistributedNotificationCenter.default().post(name: .endMenuTracking, object: nil)
-
+        
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.3
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
@@ -90,12 +90,13 @@ final class FluidMenuBarExtraStatusItem: NSObject, NSWindowDelegate {
         dismissWindow()
     }
 
-    func dismissWindow() {
+    func dismissWindow(animate: Bool = true, completionHandler: (() -> Void)? = nil) {
+        
         // Tells the system to cancel persisting the menu bar in full screen mode.
         DistributedNotificationCenter.default().post(name: .endMenuTracking, object: nil)
         
         NSAnimationContext.runAnimationGroup { context in
-            context.duration = 0.3
+            context.duration = animate ? 0.3 : 0
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
 
             window.animator().alphaValue = 0
@@ -104,6 +105,7 @@ final class FluidMenuBarExtraStatusItem: NSObject, NSWindowDelegate {
             self?.window.orderOut(nil)
             self?.window.alphaValue = 1
             self?.setButtonHighlighted(to: false)
+            completionHandler?()
         }
     }
 

--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
@@ -14,8 +14,10 @@ import SwiftUI
 /// `FluidMenuBarExtraWindow` listens for changes to the size of its content and
 /// automatically adjusts its frame to match.
 final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
+    let controller = FluidMenuBarExtraController()
+    
     private let content: () -> Content
-
+    
     private lazy var visualEffectView: NSVisualEffectView = {
         let view = NSVisualEffectView()
         view.blendingMode = .behindWindow
@@ -24,15 +26,16 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
         view.translatesAutoresizingMaskIntoConstraints = true
         return view
     }()
-
+    
     private var rootView: some View {
         content()
+            .environmentObject(controller)
             .modifier(RootViewModifier(windowTitle: title))
             .onSizeUpdate { [weak self] size in
                 self?.contentSizeDidUpdate(to: size)
             }
     }
-
+    
     private lazy var hostingView: NSHostingView<some View> = {
         let view = NSHostingView(rootView: rootView)
         // Disable NSHostingView's default automatic sizing behavior.
@@ -47,7 +50,7 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
 
     init(title: String, content: @escaping () -> Content) {
         self.content = content
-
+        
         super.init(
             contentRect: CGRect(x: 0, y: 0, width: 100, height: 100),
             styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .fullSizeContentView],


### PR DESCRIPTION
This was something I needed in order to manually control visibility of the MenuBarExtra from the views within it. 

Some examples why this is useful:
- Showing the window after completing onboarding after first app launch
- If you present other dialogs like NSOpenPanel and want to re-display the window after file selection

The root view passed to FluidMenuBarExtra automatically gets the environment object (see PR code), and so any subviews will have access to it as well. This also allows you to pass the environment object to another NSWindow for control as well.

Code example:

```swift
class AppDelegate: NSApplicationDelegate {

    private var menuBarExtra: FluidMenuBarExtra!
    
    func applicationDidFinishLaunching(_ notification: Notification) {
        menuBarExtra = FluidMenuBarExtra(title: "Producer Toolkit", systemImage:  "music.note.tv") {
            MenuBarExtraRootView()
        }
    }
}

struct MenuBarExtraRootView: View {
    @EnvironmentObject private var menuBarExtraController: FluidMenuBarExtraController
    
    var body: some View {
        // ...

        Button(action: {
            let onboardingView = OnboardingView()
                .environmentObject(menuBarExtraController)
            let hostingController = NSHostingController(rootView: onboardingView)
            let window = NSWindow(contentViewController: hostingController)
            window.level = .floating
            window.titlebarAppearsTransparent = true
            window.titleVisibility = .hidden
            window.makeKeyAndOrderFront(nil)
        }) {
            Text("App Tutorial")
        }
    }
}

struct OnboardingView: View {

    @EnvironmentObject var menuBarExtraController: FluidMenuBarExtraController
    
    var body: some View {
        // ...
    }
    
    func finishOnboarding() {
        // ...
        
        menuBarExtraController.showWindow()
    }
}
```