### PR TITLE
Dismiss window on escape

### DIFF
--- a/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
+++ b/Sources/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
@@ -109,4 +109,8 @@ final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
             self?.setFrame(nextFrame, display: true, animate: true)
         }
     }
+
+    override func cancelOperation(_ sender: Any?) {
+        resignKey()
+    }
 }


### PR DESCRIPTION
First of all, thanks for open-sourcing this library! I'm a big fan.

This matches the behaviour of `MenuBarExtra`, but this functionality is also present in all the other menu bar apps I have installed, as well as the macOS built-in menu bar windows (Wi-Fi, battery, etc)